### PR TITLE
修改 helm 源和解决 helm client 与 server 不匹配的问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,8 +199,6 @@ kubectl delete -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/mas
 
 可以根据文档安装 helm https://github.com/helm/helm/blob/master/docs/install.md
 
-#### 替换 helm 源
-
 #### 在 Mac OS 上安装
 
 ##### 通过 brew 安装

--- a/README.md
+++ b/README.md
@@ -199,30 +199,65 @@ kubectl delete -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/mas
 
 可以根据文档安装 helm https://github.com/helm/helm/blob/master/docs/install.md
 
+#### 替换 helm 源
+
 #### 在 Mac OS 上安装
+
+##### 通过 brew 安装
+
+brew 安装的版本可能会和 helm server 不兼容, 如果在后续使用 helm 安装组件的过程中出现以下错误，可以 `通过二进制包安装` 对应的版本
+
+```
+$ helm install install/kubernetes/helm/istio-init --name istio-init --namespace istio-system
+Error: incompatible versions client[v2.13.1] server[v2.12.2]
+```
 
 ```shell
 # Use homebrew on Mac
 brew install kubernetes-helm
 
+# Change helm repo
+helm repo add stable http://mirror.azure.cn/kubernetes/charts-incubator/
+
 # Install Tiller into your Kubernetes cluster
 helm init --upgrade -i registry.cn-hangzhou.aliyuncs.com/google_containers/tiller:v2.12.2 --skip-refresh
 
-# update charts repo (Optional)
+# Update charts repo (Optional)
 helm repo update
 ```
 
+##### 通过二进制包安装
+
+```
+# Download binary release
+在 https://github.com/helm/helm/releases 中找到匹配的版本并下载(需要梯子), 如: https://storage.googleapis.com/kubernetes-helm/helm-v2.12.2-darwin-amd64.tar.gz
+
+# Unpack
+
+tar -zxvf helm-v2.0.0-linux-amd64.tgz
+
+# Move it to its desired destination
+
+mv darwin-amd64/helm /usr/local/bin/helm
+
+```
+
 #### 在Windows上安装
+
+如果在后续使用 helm 安装组件的过程中出现版本兼容问题，可以参考 `通过二进制包安装` 思路安装匹配的版本
 
 ```shell
 # Use Chocolatey on Windows
 # 注：安装的时候需要保证网络能够访问googleapis这个域名
 choco install kubernetes-helm
 
+# Change helm repo
+helm repo add stable http://mirror.azure.cn/kubernetes/charts-incubator/
+
 # Install Tiller into your Kubernetes cluster
 helm init --upgrade -i registry.cn-hangzhou.aliyuncs.com/google_containers/tiller:v2.12.2 --skip-refresh
 
-# update charts repo (Optional)
+# Update charts repo (Optional)
 helm repo update
 ```
 


### PR DESCRIPTION
1. 修改国内 helm 源解决 helm repo update 失败或者找不到需要安装的组件问题
2. 添加二进制包安装 helm 的方式，解决通过如 brew 等包管理器安装的 helm client 和 server 不兼容的问题