### PR TITLE
fix pull image nginx-ingress-controller:0.26.1 fail

### DIFF
--- a/images.properties
+++ b/images.properties
@@ -7,4 +7,4 @@ k8s.gcr.io/etcd:3.3.10=registry.cn-hangzhou.aliyuncs.com/google_containers/etcd:
 k8s.gcr.io/coredns:1.3.1=registry.cn-hangzhou.aliyuncs.com/google_containers/coredns:1.3.1
 k8s.gcr.io/kubernetes-dashboard-amd64:v1.10.1=registry.cn-hangzhou.aliyuncs.com/google_containers/kubernetes-dashboard-amd64:v1.10.1
 quay.io/coreos/hyperkube:v1.7.6_coreos.0=registry.cn-hangzhou.aliyuncs.com/coreos_containers/hyperkube:v1.7.6_coreos.0
-quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.25.1=registry.cn-hangzhou.aliyuncs.com/google_containers/nginx-ingress-controller:0.25.1
+quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.26.1=registry.cn-hangzhou.aliyuncs.com/google_containers/nginx-ingress-controller:0.26.1


### PR DESCRIPTION
升级nginx-ingress-controller到0.26.1 ,解决容器拉取0.26.1 版本失败