### PR TITLE
windows os remove "\r"

### DIFF
--- a/load_images_for_windows.sh
+++ b/load_images_for_windows.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+file="images.properties"
+
+if [ -f "$file" ]
+then
+  echo "$file found."
+  #remove "\r" by perl
+  perl -pi -e 's/\r//' $file
+  while IFS='=' read -r key value
+  do
+    #echo "${key}=${value}"
+    docker pull ${value}
+    docker tag ${value} ${key}
+    docker rmi ${value}
+  done < "$file"
+
+else
+  echo "$file not found."
+fi
+


### PR DESCRIPTION
复制load_images.s文件一份命名为load_images_for_windows.sh，
增加perl -pi -e 's/\r//' $file 来去除Windows os 默认将文本文件中的换行符强制转为的 “\r”，
Windows系统直接运行load_images_for_windows.sh即可，运行后修改 images.properties文件，把images.properties文件中的“\r”去除。