### PR TITLE
release k8s v1.21.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 * 当前 master 分支已经在 Docker for Mac/Windows 3.1.0 (包含 Docker CE 20.10.3 和 Kubernetes 1.19.7) 版本测试通过
 * 如果需要测试其他版本，请查看 Docker Desktop版本，Docker -> About Docker Desktop
   ![about](images/about.png)
+  * 如Kubernetes版本为 v1.21.1, 请使用下面命令切换 [v1.21.1 分支](https://github.com/AliyunContainerService/k8s-for-docker-desktop/tree/v1.21.1) ```git checkout v1.21.1```
   * 如Kubernetes版本为 v1.19.3, 请使用下面命令切换 [v1.19.3 分支](https://github.com/AliyunContainerService/k8s-for-docker-desktop/tree/v1.19.3) ```git checkout v1.19.3```
   * 如Kubernetes版本为 v1.19.2, 请使用下面命令切换 [v1.19.2 分支](https://github.com/AliyunContainerService/k8s-for-docker-desktop/tree/v1.19.2) ```git checkout v1.19.2```
   * 如Kubernetes版本为 v1.18.8, 请使用下面命令切换 [v1.18.8 分支](https://github.com/AliyunContainerService/k8s-for-docker-desktop/tree/v1.18.8) ```git checkout v1.18.8```

--- a/README_en.md
+++ b/README_en.md
@@ -7,6 +7,7 @@ NOTE:
 * The master branch is tested with Docker Desktop for Mac/Windows version 3.1.0 (with Docker CE 20.10.3 and Kubernetes 1.19.7). 
 * If you want to use with other version, pls check version of Kubernetes，Docker -> About Docker Desktop
     ![about](images/about.png)
+    * For Kubernetes v1.21.1, please use the v1.21.1 branch ```git checkout v1.21.1```
     * For Kubernetes v1.19.3, please use the v1.19.3 branch ```git checkout v1.19.3```
     * For Kubernetes v1.19.2, please use the v1.19.2 branch ```git checkout v1.19.2```
     * For Kubernetes v1.18.8, please use the v1.18.8 branch ```git checkout v1.18.8```

--- a/images.properties
+++ b/images.properties
@@ -1,8 +1,8 @@
-k8s.gcr.io/pause:3.2=registry.cn-hangzhou.aliyuncs.com/google_containers/pause:3.2
-k8s.gcr.io/kube-controller-manager:v1.19.7=registry.cn-hangzhou.aliyuncs.com/google_containers/kube-controller-manager:v1.19.7
-k8s.gcr.io/kube-scheduler:v1.19.7=registry.cn-hangzhou.aliyuncs.com/google_containers/kube-scheduler:v1.19.7
-k8s.gcr.io/kube-proxy:v1.19.7=registry.cn-hangzhou.aliyuncs.com/google_containers/kube-proxy:v1.19.7
-k8s.gcr.io/kube-apiserver:v1.19.7=registry.cn-hangzhou.aliyuncs.com/google_containers/kube-apiserver:v1.19.7
+k8s.gcr.io/pause:3.4.1=registry.cn-hangzhou.aliyuncs.com/google_containers/pause:3.4.1
+k8s.gcr.io/kube-controller-manager:v1.21.1=registry.cn-hangzhou.aliyuncs.com/google_containers/kube-controller-manager:v1.21.1
+k8s.gcr.io/kube-scheduler:v1.21.1=registry.cn-hangzhou.aliyuncs.com/google_containers/kube-scheduler:v1.21.1
+k8s.gcr.io/kube-proxy:v1.21.1=registry.cn-hangzhou.aliyuncs.com/google_containers/kube-proxy:v1.21.1
+k8s.gcr.io/kube-apiserver:v1.21.1=registry.cn-hangzhou.aliyuncs.com/google_containers/kube-apiserver:v1.21.1
 k8s.gcr.io/etcd:3.4.13-0=registry.cn-hangzhou.aliyuncs.com/google_containers/etcd:3.4.13-0
-k8s.gcr.io/coredns:1.7.0=registry.cn-hangzhou.aliyuncs.com/google_containers/coredns:1.7.0
+k8s.gcr.io/coredns:1.8.0=registry.cn-hangzhou.aliyuncs.com/google_containers/coredns:1.8.0
 quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.26.1=registry.cn-hangzhou.aliyuncs.com/google_containers/nginx-ingress-controller:0.26.1


### PR DESCRIPTION
```
REPOSITORY                           TAG                                                     IMAGE ID       CREATED        SIZE
docker/desktop-kubernetes            kubernetes-v1.21.1-cni-v0.8.5-critools-v1.17.0-debian   e94f03666724   4 weeks ago    302MB
k8s.gcr.io/kube-apiserver            v1.21.1                                                 771ffcf9ca63   4 weeks ago    126MB
k8s.gcr.io/kube-proxy                v1.21.1                                                 4359e752b596   4 weeks ago    131MB
k8s.gcr.io/kube-controller-manager   v1.21.1                                                 e16544fd47b0   4 weeks ago    120MB
k8s.gcr.io/kube-scheduler            v1.21.1                                                 a4183b88f6e6   4 weeks ago    50.6MB
docker/desktop-vpnkit-controller     v2.0                                                    8c2c38aa676e   5 weeks ago    21MB
docker/desktop-storage-provisioner   v2.0                                                    99f89471f470   6 weeks ago    41.9MB
k8s.gcr.io/pause                     3.4.1                                                   0f8457a4c2ec   5 months ago   683kB
k8s.gcr.io/coredns/coredns           v1.8.0                                                  296a6d5035e2   7 months ago   42.5MB
k8s.gcr.io/etcd                      3.4.13-0                                                0369cf4303ff   9 months ago   253MB
```