### PR TITLE
update coredns path

### DIFF
--- a/images.properties
+++ b/images.properties
@@ -4,5 +4,5 @@ k8s.gcr.io/kube-scheduler:v1.21.1=registry.cn-hangzhou.aliyuncs.com/google_conta
 k8s.gcr.io/kube-proxy:v1.21.1=registry.cn-hangzhou.aliyuncs.com/google_containers/kube-proxy:v1.21.1
 k8s.gcr.io/kube-apiserver:v1.21.1=registry.cn-hangzhou.aliyuncs.com/google_containers/kube-apiserver:v1.21.1
 k8s.gcr.io/etcd:3.4.13-0=registry.cn-hangzhou.aliyuncs.com/google_containers/etcd:3.4.13-0
-k8s.gcr.io/coredns:1.8.0=registry.cn-hangzhou.aliyuncs.com/google_containers/coredns:1.8.0
+k8s.gcr.io/coredns/coredns:v1.8.0=registry.cn-hangzhou.aliyuncs.com/google_containers/coredns:1.8.0
 quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.26.1=registry.cn-hangzhou.aliyuncs.com/google_containers/nginx-ingress-controller:0.26.1


### PR DESCRIPTION
修复路径，否则会报 ```Failed to pull image "k8s.gcr.io/coredns/coredns:v1.8.0``` 错误，导致pod coredns ImagePullBackOff